### PR TITLE
Performance improvement: Added/Removed buildings are saved on close and game save.

### DIFF
--- a/Code/GUI/UITitleBar.cs
+++ b/Code/GUI/UITitleBar.cs
@@ -1,5 +1,4 @@
-﻿using ColossalFramework;
-using ColossalFramework.UI;
+﻿using ColossalFramework.UI;
 using DistrictStylesPlus.Code.Managers;
 using UnityEngine;
 

--- a/Code/GUI/UITitleBar.cs
+++ b/Code/GUI/UITitleBar.cs
@@ -1,4 +1,6 @@
-﻿using ColossalFramework.UI;
+﻿using ColossalFramework;
+using ColossalFramework.UI;
+using DistrictStylesPlus.Code.Managers;
 using UnityEngine;
 
 namespace DistrictStylesPlus.Code.GUI
@@ -67,9 +69,11 @@ namespace DistrictStylesPlus.Code.GUI
             _close.relativePosition = new Vector3(width - 35, 2);
             _close.normalBgSprite = "buttonclose";
             _close.hoveredBgSprite = "buttonclosehover";
-            _close.pressedBgSprite = "buttonclosepressed";
+            _close.pressedBgSprite = "loading_icon";
+            _close.tooltip = "Save and Close";
             _close.eventClick += (component, param) =>
             {
+                StartCoroutine(DSPDistrictStylePackageManager.SaveChangedAssetsOfDistrictStyleMetaDataAsync());
                 if (isModal)
                     UIView.PopModal();
                 parent.Hide();

--- a/Code/Managers/DSPDistrictStylePackageManager.cs
+++ b/Code/Managers/DSPDistrictStylePackageManager.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using BuffPanel;
 using ColossalFramework;
 using ColossalFramework.Packaging;
 using DistrictStylesPlus.Code.GUI;
@@ -14,10 +16,17 @@ namespace DistrictStylesPlus.Code.Managers
     {
         
         public const string VanillaPrefix = "System";
+
+        /// <summary>
+        /// District style meta datas for which assets have been added or removed. Uses district style name as key.
+        /// </summary>
+        private static readonly Dictionary<String, DistrictStyleMetaData> ModifiedDistrictStyleMetaDatas = 
+            new Dictionary<String, DistrictStyleMetaData>();
         
         internal static void RemoveDistrictStylePackage(string dsFullName)
         {
             PackageManager.DisableEvents();
+            ModifiedDistrictStyleMetaDatas.Remove(dsFullName);
             var dsAsset = PackageManager.FindAssetByName(dsFullName);
             PackageManager.Remove(dsAsset.package);
             File.Delete(dsAsset.package.packagePath);
@@ -85,11 +94,11 @@ namespace DistrictStylesPlus.Code.Managers
 
         /// <summary>
         /// It refreshes district style assets metadata.
+        /// To save changes to disk, call <see cref="SaveChangedAssetsOfDistrictStyleMetaData"/>.
         /// </summary>
         /// <param name="districtStyle">District Style which metadata should be refreshed</param>
         internal static void RefreshDistrictStyleAssetsMetaData(DistrictStyle districtStyle)
         {
-            PackageManager.DisableEvents();
             var dsMeta = GetDistrictStyleMetaDataByName(districtStyle.Name);
             
             if (dsMeta == null)
@@ -116,14 +125,14 @@ namespace DistrictStylesPlus.Code.Managers
             }
 
             dsMeta.assets = newAssetList;
-            StylesHelper.SaveStyle(dsMeta, dsMeta.name, false);
-            PackageManager.EnabledEvents();
-            PackageManager.ForcePackagesChanged();
+            ModifiedDistrictStyleMetaDatas[districtStyle.Name] = dsMeta;
         }
         
+        /// <summary>
+        /// To save changes to disk, call <see cref="SaveChangedAssetsOfDistrictStyleMetaData"/>.
+        /// </summary>
         internal static void AddAssetToDistrictStyleMetaData(string districtStyleName, string buildingInfoName)
         {
-            PackageManager.DisableEvents();
             var dsMeta = GetDistrictStyleMetaDataByName(districtStyleName);
 
             if (dsMeta == null)
@@ -136,27 +145,25 @@ namespace DistrictStylesPlus.Code.Managers
             {
                 dsMeta.assets = new string[0];
             }
-            
-            var newAssetList = new string[dsMeta.assets.Length + 1];
-            dsMeta.assets.CopyTo(newAssetList, 0);
-            var assetName = GetPackageAssetName(buildingInfoName);
-            
+
+            var assetName = GetPackageAssetName(buildingInfoName);            
             if (!dsMeta.assets.Contains(assetName))
             {
+                var newAssetList = new string[dsMeta.assets.Length + 1];
+                dsMeta.assets.CopyTo(newAssetList, 0);
+
                 Logging.DebugLog($"Add asset {assetName}");
                 newAssetList[newAssetList.Length - 1] = assetName;
                 dsMeta.assets = newAssetList;
-                StylesHelper.SaveStyle(dsMeta, dsMeta.name, false);
+                ModifiedDistrictStyleMetaDatas[districtStyleName] = dsMeta;
             }
-            
-            PackageManager.EnabledEvents();
-            PackageManager.ForcePackagesChanged();
         }
         
+        /// <summary>
+        /// To save changes to disk, call <see cref="SaveChangedAssetsOfDistrictStyleMetaData"/>.
+        /// </summary>
         internal static void RemoveAssetFromDistrictStyleMetaData(string districtStyleName, string buildingInfoName)
-        {
-            PackageManager.DisableEvents();
-            
+        {            
             var dsMeta = GetDistrictStyleMetaDataByName(districtStyleName);
             if (dsMeta == null)
             {
@@ -179,13 +186,52 @@ namespace DistrictStylesPlus.Code.Managers
                         Array.Copy(dsMeta.assets, 0, array2, 0, k);
                         Array.Copy(dsMeta.assets, k + 1, array2, k, dsMeta.assets.Length - k - 1);
                         dsMeta.assets = array2;
-                        StylesHelper.SaveStyle(dsMeta, dsMeta.name, false);
+                        ModifiedDistrictStyleMetaDatas[districtStyleName] = dsMeta;
                         break;
                     }
                 }
             }
-            PackageManager.EnabledEvents();
-            PackageManager.ForcePackagesChanged();
+        }
+
+        /// <summary>
+        /// Save changes of the district style meta data performed by 
+        /// <see cref="RemoveAssetFromDistrictStyleMetaData"/>,
+        /// <see cref="AddAssetToDistrictStyleMetaData"/> and
+        /// <see cref="RefreshDistrictStyleAssetsMetaData"/>.
+        /// This is a slow operation, as it writes data to disk.
+        /// Implemented as Unity Coroutine. 
+        /// </summary>
+        internal static IEnumerator SaveChangedAssetsOfDistrictStyleMetaData() 
+        {
+            // PackageManager.DisableEvents() gets already called by StylesHelper.SaveStyle
+
+            if (ModifiedDistrictStyleMetaDatas.Count == 0) {
+                yield break;
+            }
+
+            foreach (DistrictStyleMetaData dsMeta in ModifiedDistrictStyleMetaDatas.Values)
+            {
+                yield return 0;
+                StylesHelper.SaveStyle(dsMeta, dsMeta.name, false);
+            }
+            ModifiedDistrictStyleMetaDatas.Clear();
+
+            // PackageManager.EnabledEvents() gets already called by StylesHelper.SaveStyle
+            // PackageManager.ForcePackagesChanged() does it have to be called? It can't be called in a async Task 
+            // => If it is required, move it out of the async Task and wait for it to finish before calling..  
+            yield return 0;
+        }
+
+        internal static IEnumerator SaveChangedAssetsOfDistrictStyleMetaDataAsync() 
+        {
+            // Use LoadSaveStatus just like the game does to save a game 
+            AsyncTask task = (AsyncTask)(LoadSaveStatus.activeTask = Singleton<SimulationManager>.instance.AddAction(
+                "Saving", DSPDistrictStylePackageManager.SaveChangedAssetsOfDistrictStyleMetaData()
+            ));
+            while (!task.completedOrFailed)
+            {
+                yield return 0;
+            }
         }
         
         internal static string GetPackageAssetName(string buildingInfoName)
@@ -198,6 +244,10 @@ namespace DistrictStylesPlus.Code.Managers
         
         private static DistrictStyleMetaData GetDistrictStyleMetaDataByName(string dsName)
         {
+            if (ModifiedDistrictStyleMetaDatas.ContainsKey(dsName)) {
+                return ModifiedDistrictStyleMetaDatas.GetValueSafe(dsName);
+            }
+
             DistrictStyleMetaData dsMeta = null;
             var dsMetaList = GetDistrictStyleMetaDataList();
             foreach (var dsMetaInfo in dsMetaList)

--- a/Code/Managers/DSPDistrictStylePackageManager.cs
+++ b/Code/Managers/DSPDistrictStylePackageManager.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using BuffPanel;
 using ColossalFramework;
 using ColossalFramework.Packaging;
 using DistrictStylesPlus.Code.GUI;

--- a/Code/Patches/SavePanelPatch.cs
+++ b/Code/Patches/SavePanelPatch.cs
@@ -12,8 +12,7 @@ namespace DistrictStylesPlus.Code.Patches
         
         /// <summary>
         /// Called to save the game (including auto save).
-        /// To increase performance, district styles are only written on disk,
-        /// when the game is saved.
+        /// To prevent data loss, district styles are written on disk, when the game is saved.
         /// </summary>
         [HarmonyPrefix]
         [HarmonyPatch(typeof(SavePanel), "SaveGame", new Type[] { typeof(string), typeof(bool), typeof(bool) })]

--- a/Code/Patches/SavePanelPatch.cs
+++ b/Code/Patches/SavePanelPatch.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using DistrictStylesPlus.Code.Managers;
+using HarmonyLib;
+using UnityEngine;
+
+namespace DistrictStylesPlus.Code.Patches
+{
+    
+    [HarmonyPatch]
+    public static class SavePanelPatch
+    {
+        
+        /// <summary>
+        /// Called to save the game (including auto save).
+        /// To increase performance, district styles are only written on disk,
+        /// when the game is saved.
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(SavePanel), "SaveGame", new Type[] { typeof(string), typeof(bool), typeof(bool) })]
+        public static void SaveGamePrefix(SavePanel __instance, string saveName, bool useCloud, bool quitAfterSaving)
+        {
+            __instance.StartCoroutine(DSPDistrictStylePackageManager.SaveChangedAssetsOfDistrictStyleMetaData());
+        }
+        
+    }
+}


### PR DESCRIPTION
Old behaviour: Adding/Removing a building to a district by clicking on the checkbox writes the changes to disk. This takes several seconds.
New behaviour: District styles are written to disk if they are created, deleted, the contained buildings are changed and a) the DS panel is closed or b) the game is saved. 

Tested and styles seems to work like before with a lot of other mods running too. 
PackageManager.ForcePackagesChanged() is removed to allow async saving, but I personally don't understand what it does and if it is needed. So far no problems though...